### PR TITLE
Fixed OAuth controller private

### DIFF
--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -39,6 +39,6 @@
             <tag name="controller.service_arguments" />
         </service>
 
-        <service id="SymfonyCorp\Bundle\ConnectBundle\Controller\OAuthController" alias="symfony_connect.oauth_controller" />
+        <service id="SymfonyCorp\Bundle\ConnectBundle\Controller\OAuthController" alias="symfony_connect.oauth_controller" public="true"/>
     </services>
 </container>

--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -39,6 +39,6 @@
             <tag name="controller.service_arguments" />
         </service>
 
-        <service id="SymfonyCorp\Bundle\ConnectBundle\Controller\OAuthController" alias="symfony_connect.oauth_controller" public="true"/>
+        <service id="SymfonyCorp\Bundle\ConnectBundle\Controller\OAuthController" alias="symfony_connect.oauth_controller" public="true" />
     </services>
 </container>


### PR DESCRIPTION
According to that error:
```
The controller for URI "/connect/login" is not callable. Controller "SymfonyCorp\Bundle\ConnectBundle\Controller\OAuthController" cannot be fetched from the container because it is private. Did you forget to tag the service with "controller.service_arguments"?
```

OAuthController should be public I guess. As it was before commit 09c5e8602c759fe5e93dd4a20604272776fcaadf