### PR TITLE
Fix compatibility with Security 5.2 and bump symfonycorp/connect version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,8 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": ">=7.1.3",
-        "symfonycorp/connect": "^6.3"
+        "php": ">=7.2.4",
+        "symfonycorp/connect": "^7.2"
     },
     "require-dev": {
         "symfony/security-bundle": "^4.4|^5.0",

--- a/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
+++ b/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
@@ -14,6 +14,12 @@ namespace SymfonyCorp\Bundle\ConnectBundle\DependencyInjection\Security\Factory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\EntryPointFactoryInterface;
 
-class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface, EntryPointFactoryInterface
-{
+if (interface_exists(EntryPointFactoryInterface::class)) {
+    class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface, EntryPointFactoryInterface
+    {
+    }
+} else {
+    class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface
+    {
+    }
 }


### PR DESCRIPTION
Hi,

This PR is intended to handle break change of Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\EntryPointFactoryInterface interface being deleted in Security component in its 5.2 version.

Feel free to make your feedbacks :)

Regards,

Guillaume